### PR TITLE
Adding more instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Once the 🐶 Hoodie app is running, you can open your browser to
 localhost:8080
 ```
 
+You can compare this with the live version of this app by opening your browser to
+```
+https://camp-tutorial.hood.ie/
+```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ to learn all the basics about `hoodie.store` and `hoodie.account`.
 
 - [git](http://www.git-scm.com/)
 - [node](https://nodejs.org/en/) v4.4+
-- npm v3+. npm comes with node, check with `npm -v`, install latest: `npm install -g npm`
+- [npm](https://www.npmjs.com/) v3+
+- Note: npm comes with node. To check what version you have, run: `npm -v`. To install the latest, run: `npm install -g npm`
 
 ## Installation & start
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Once installation is done, you can start the app with
 npm start
 ```
 
+Once the 🐶 Hoodie app is running, you can open your browser to
+
+```
+localhost:8080
+```
+
+
 ## License
 
 [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
This is a PR for these 3 small `README.md` file additions. It is my first step as a part of this ⛺ Camp Issue: https://github.com/hoodiehq/camp/issues/23 I even made a screenshot of a preview of the resulting changes:

![screenshot 2016-10-01 21 03 34](https://cloud.githubusercontent.com/assets/3673236/19018536/88d308ac-881a-11e6-9b7a-df44687296cd.png)

This PR adds:
1. Link to npm and edits the npm note to a complete sentence
2. Adds a note to users to open to localhost:8080 ... it is different from the command line instructions. For example, mine says: 
![screenshot 2016-10-01 21 05 01](https://cloud.githubusercontent.com/assets/3673236/19018540/c0277e28-881a-11e6-966e-dbb7ad1f0ee6.png)
3. Adds link to the production site just in case people don't see it already at the top 
