### PR TITLE
Make service-worker-status more obviously dynamic

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -85,7 +85,7 @@ body {
 }
 
 [data-service-worker="ready"] .service-worker.ready {
-  display: block;i
+  display: block;
 }
 [data-service-worker="error"] .service-worker.error {
   display: block;

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -73,8 +73,19 @@ body {
 .service-worker.loading {
   display: block;
 }
+
+.service-worker-status-text {
+  text-align: center;
+}
+
+.service-worker-status {
+  font-size: 1.2em; 
+  border: 1px solid black;
+  padding: 0 3px 0 3px; 
+}
+
 [data-service-worker="ready"] .service-worker.ready {
-  display: block;
+  display: block;i
 }
 [data-service-worker="error"] .service-worker.error {
   display: block;

--- a/public/index.html
+++ b/public/index.html
@@ -37,10 +37,10 @@
         </p>
 
         <p>
-          Let’s jump right in: first off, let's get some fundamentals out of the way. This entire tutorial is being downloaded with the code you see below, so this page can be run offline, too. We use ServiceWorker for that. Your ServiceWorker status is:
+          Let’s jump right in: first off, let's get some fundamentals out of the way. This entire tutorial is being downloaded with the code you see below, so this page can be run offline, too. We use ServiceWorker for that.
         </p>
 
-        <p><strong class="service-worker-status"></strong></p>
+        <p>Your ServiceWorker status is: <strong class="service-worker-status"></strong></p>
 
 
 <script>

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
           Let’s jump right in: first off, let's get some fundamentals out of the way. This entire tutorial is being downloaded with the code you see below, so this page can be run offline, too. We use ServiceWorker for that.
         </p>
 
-        <p>Your ServiceWorker status is: <strong class="service-worker-status"></strong></p>
+        <p class="service-worker-status-text">Your ServiceWorker status is: <strong class="service-worker-status"></strong></p>
 
 
 <script>

--- a/public/index.html
+++ b/public/index.html
@@ -38,8 +38,10 @@
 
         <p>
           Let’s jump right in: first off, let's get some fundamentals out of the way. This entire tutorial is being downloaded with the code you see below, so this page can be run offline, too. We use ServiceWorker for that. Your ServiceWorker status is:
-          <strong class="service-worker-status"></strong>
         </p>
+
+        <p><strong class="service-worker-status"></strong></p>
+
 
 <script>
 


### PR DESCRIPTION
The service-worker-status class above the code on page 1 is not intuitively understood as a dynamic element. When I first read it, I skimmed right over it and assumed it was just some styled text.

By giving status its own paragraph, centering it and putting a simple border around the element, it will me more easy for humans to interpret it as dynamic. And important.

![service-worker-status](https://cloud.githubusercontent.com/assets/14797009/19140089/c085afb2-8b3e-11e6-8950-882f909fd20a.png)
