### PR TITLE
Make dynamic status indicators uniform and pretty

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -84,7 +84,7 @@ body {
 .connection-status {
   font-size: 1.2em; 
   border: 1px solid black;
-  padding: 0 3px 0 3px; 
+  padding: 0 5px 2px 5px; 
 }
 
 [data-service-worker="ready"] .service-worker.ready {

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -83,7 +83,7 @@ body {
 .status,
 .connection-status {
   font-size: 1.2em; 
-  border: 1px solid black;
+  border: 1px solid #428bca;
   padding: 0 5px 2px 5px; 
 }
 

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -78,7 +78,10 @@ body {
   text-align: center;
 }
 
-.service-worker-status {
+.service-worker-status,
+.connect-status,
+.status,
+.connection-status {
   font-size: 1.2em; 
   border: 1px solid black;
   padding: 0 3px 0 3px; 

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -84,6 +84,7 @@ body {
 .connection-status {
   font-size: 1.2em; 
   border: 1px solid #428bca;
+  border-radius: 4px;
   padding: 0 5px 2px 5px; 
 }
 

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -85,7 +85,7 @@ body {
 }
 
 [data-service-worker="ready"] .service-worker.ready {
-  display: block;i
+  display: block;
 }
 [data-service-worker="error"] .service-worker.error {
   display: block;

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -85,7 +85,7 @@ body {
 }
 
 [data-service-worker="ready"] .service-worker.ready {
-  display: block;
+  display: block;i
 }
 [data-service-worker="error"] .service-worker.error {
   display: block;

--- a/public/index.html
+++ b/public/index.html
@@ -37,10 +37,10 @@
         </p>
 
         <p>
-          Let’s jump right in: first off, let's get some fundamentals out of the way. This entire tutorial is being downloaded with the code you see below, so this page can be run offline, too. We use ServiceWorker for that. Your ServiceWorker status is:
+          Let’s jump right in: first off, let's get some fundamentals out of the way. This entire tutorial is being downloaded with the code you see below, so this page can be run offline, too. We use ServiceWorker for that.
         </p>
 
-        <p><strong class="service-worker-status"></strong></p>
+        <p>Your ServiceWorker status is: <strong class="service-worker-status"></strong></p>
 
 
 <script>

--- a/public/index.html
+++ b/public/index.html
@@ -37,10 +37,10 @@
         </p>
 
         <p>
-          Let’s jump right in: first off, let's get some fundamentals out of the way. This entire tutorial is being downloaded with the code you see below, so this page can be run offline, too. We use ServiceWorker for that.
+          Let’s jump right in: first off, let's get some fundamentals out of the way. This entire tutorial is being downloaded with the code you see below, so this page can be run offline, too. We use ServiceWorker for that. Your ServiceWorker status is:
         </p>
 
-        <p class="service-worker-status-text">Your ServiceWorker status is: <strong class="service-worker-status"></strong></p>
+        <p><strong class="service-worker-status"></strong></p>
 
 
 <script>

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
           Let’s jump right in: first off, let's get some fundamentals out of the way. This entire tutorial is being downloaded with the code you see below, so this page can be run offline, too. We use ServiceWorker for that.
         </p>
 
-        <p>Your ServiceWorker status is: <strong class="service-worker-status"></strong></p>
+        <p class="service-worker-status-text">Your ServiceWorker status is: <strong class="service-worker-status"></strong></p>
 
 
 <script>


### PR DESCRIPTION
There are several other HTML classes that link to dynamic status on the website. To make sure all of these look obviously dynamic and fit with the style and color scheme they should be grouped together.

Also it'd be nice if the border color and rounded corners of these boxes were the same as is used elsewhere on the site. So #428bca with 4px rounding. "It really ties the room together, man!"
![1_hoodie_index](https://cloud.githubusercontent.com/assets/14797009/19261578/01a09d7a-8f47-11e6-8e0d-c9cee3c5615a.png)
![2_hoodie](https://cloud.githubusercontent.com/assets/14797009/19261580/0460b93c-8f47-11e6-8794-18d480b3ca0b.png)
![7_hoodie](https://cloud.githubusercontent.com/assets/14797009/19261582/09997718-8f47-11e6-97ce-fd7b37ce7287.png)
![9_hoodie](https://cloud.githubusercontent.com/assets/14797009/19261590/195415b4-8f47-11e6-9868-113c9484122d.png)
