### PR TITLE
fix: Update event handlers change color of the same DOM element.

### DIFF
--- a/public/6.html
+++ b/public/6.html
@@ -49,13 +49,13 @@ function addNewColorToList(color) {
 function removeColorFromList(color) {
   $('.colorList').find('[data-id="'+color.id+'"]').remove();
   if ($('.colorList li').length === 0)  {
-    $('html').css('background', 'transparent');
+    $(document.body).css('background', 'transparent');
   }
 }
 function updateColorOnList(color) {
   $('.colorList').find('[data-id="'+color.id+'"]').text(color.name+' (id: '+color.id+')');
   if (color.id === lastColorId) {
-    $('html').css('background', color.name);
+    $(document.body).css('background', color.name);
   }
 }
 


### PR DESCRIPTION
Two of the three event handlers on page 6 were updating `.html` while the third was updating `document.body`.  When the user would update an existing color, the background didn't appear to reflect that change.
